### PR TITLE
RWStore.properties destination fixed

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,7 +3,7 @@
 - name: Copy templated blazegraph config files
   template:
     src: "{{ item }}"
-    dest: "{{ blazegraph_home_dir }}/conf/{{ item }}"
+    dest: "{{ blazegraph_RWStore_path }}{{ item }}"
     owner: "{{ blazegraph_user }}"
     group: "{{ blazegraph_user }}"
   with_items:


### PR DESCRIPTION
Wait for Blazegraph to come up - FAILED before this fix.