### PR TITLE
Ensures that ansible is using https to call maven central (repo1.mave…

### DIFF
--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -2,7 +2,7 @@
 
 - name: Download blazegraph war
   get_url:
-    url: http://repo1.maven.org/maven2/com/blazegraph/bigdata-war/{{ blazegraph_version }}/bigdata-war-{{ blazegraph_version }}.war
+    url: https://repo1.maven.org/maven2/com/blazegraph/bigdata-war/{{ blazegraph_version }}/bigdata-war-{{ blazegraph_version }}.war
     dest: "{{ blazegraph_war_path }}"
     owner: "{{ blazegraph_user }}"
     group: "{{ blazegraph_user }}"


### PR DESCRIPTION
…n.org).

**GitHub Issue**: N/A

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?
Maven Central now requires https.  This PR resolves the 501 errors that appeared today.

# Interested parties
@Islandora-Devops/committers
