### PR TITLE
Update to run on Tomcat 9 on Ubuntu 20.04 Focal64

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@ Available variables are listed below, along with default values:
 # Blazegraph version
 blazegraph_version: 2.1.4
 # User to install with
-blazegraph_user: tomcat8
+blazegraph_user: tomcat
 # Where to install to
 blazegraph_home_dir: /opt/blazegraph
 # Servlet container home directory
-blazegraph_tomcat_home: /var/lib/tomcat8
+blazegraph_tomcat_home: /var/lib/tomcat9
 # Path to install the WAR to
 blazegraph_war_path: "{{ blazegraph_tomcat_home }}/webapps/bigdata.war"
 # Log4J template file
 blazegraph_log4j_template: log4j.properties
 # Log directory
-blazegraph_log_dir: /var/log/tomcat8/blazegraph
+blazegraph_log_dir: /var/log/tomcat9/blazegraph
 # Path to install the log4k settings to
 blazegraph_log4j_path: "{{ blazegraph_tomcat_home }}/webapps/bigdata/WEB-INF/classes/log4j.properties"
 ```
@@ -34,17 +34,17 @@ There are additional configuration options available and documented in [defaults
 
 This expects an Apache Tomcat container to install into. 
 
-This role should also handle a notification "restart tomcat8". 
+This role should also handle a notification "restart tomcat9". 
 
 We recommend the following:
-* Islandora-Devops.tomcat8
-     * [Github](https://github.com/Islandora-Devops/ansible-role-tomcat8)
-     * [Galaxy](https://galaxy.ansible.com/Islandora-Devops/tomcat8/)
+* Islandora-Devops.tomcat9
+     * [Github](https://github.com/Islandora-Devops/ansible-role-tomcat9)
+     * [Galaxy](https://galaxy.ansible.com/Islandora-Devops/tomcat9/)
   
 In order for blazegraph to find its configuration files you have two options: 
 * Specify it in the blazegraph web.xml file:
   * This can be done automatically the role be specifying `blazegraph_webxml_template: yes` (default)
-* Set the blazegraph options in your `JAVA_OPTS` environment variable. How to do this depends on the role. An example using Islandora-Devops.tomcat8 can be found [here](tests/java_opts.yml).
+* Set the blazegraph options in your `JAVA_OPTS` environment variable. How to do this depends on the role. An example using Islandora-Devops.tomcat9 can be found [here](tests/java_opts.yml).
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,11 @@
 blazegraph_version: 2.1.4
-blazegraph_user: tomcat8
+blazegraph_user: tomcat
 blazegraph_home_dir: /opt/blazegraph
-blazegraph_war_path: "{{ tomcat8_home }}/webapps/bigdata.war"
+blazegraph_war_path: "{{ tomcat9_home }}/webapps/bigdata.war"
 blazegraph_log4j_template: log4j.properties
-blazegraph_log_dir: /var/log/tomcat8/blazegraph
-blazegraph_log4j_path: "{{ tomcat8_home }}/webapps/bigdata/WEB-INF/classes/log4j.properties"
-blazegraph_webxml_path: "{{ tomcat8_home }}/webapps/bigdata/WEB-INF/web.xml"
+blazegraph_log_dir: /var/log/tomcat9/blazegraph
+blazegraph_log4j_path: "{{ tomcat9_home }}/webapps/bigdata/WEB-INF/classes/log4j.properties"
+blazegraph_webxml_path: "{{ tomcat9_home }}/webapps/bigdata/WEB-INF/web.xml"
 blazegraph_webxml_template: yes
 
 # -- All of these are properties that go into RWStore.properties

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -8,7 +8,7 @@
     group: "{{ blazegraph_user }}"
   with_items:
     - RWStore.properties
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Copy blazegraph config files
   copy:
@@ -19,7 +19,7 @@
   with_items:
     - blazegraph.properties
     - inference.nt
-  notify: restart tomcat8
+  notify: restart tomcat9
 
 - name: Drop in templated web.xml file
   template:
@@ -27,5 +27,5 @@
     dest: "{{ blazegraph_webxml_path }}"
     owner: "{{ blazegraph_user }}"
     group: "{{ blazegraph_user }}"
-  notify: restart tomcat8
+  notify: restart tomcat9
   when: blazegraph_webxml_template

--- a/tasks/logging.yml
+++ b/tasks/logging.yml
@@ -11,4 +11,4 @@
     dest: "{{blazegraph_log4j_path}}"
     owner: "{{ blazegraph_user }}"
     group: "{{ blazegraph_user }}"
-  notify: restart tomcat8
+  notify: restart tomcat9

--- a/tests/java_opts.yml
+++ b/tests/java_opts.yml
@@ -26,8 +26,8 @@
       when: "ansible_os_family == 'RedHat'"
       java_packages:
         - java-1.8.0-openjdk
-    - role: Islandora-Devops.tomcat8
-      tomcat8_java_opts:
+    - role: Islandora-Devops.tomcat9
+      tomcat9_java_opts:
         - -Djava.awt.headless=true
         - -Xmx128m
         - -XX:+UseConcMarkSweepGC

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,4 @@
 ---
   - src: geerlingguy.java
     version: 1.8.1
-  - Islandora-Devops.tomcat8
+  - Islandora-Devops.tomcat9

--- a/tests/web_xml.yml
+++ b/tests/web_xml.yml
@@ -26,5 +26,5 @@
       when: "ansible_os_family == 'RedHat'"
       java_packages:
         - java-1.8.0-openjdk
-    - role: Islandora-Devops.tomcat8
+    - role: Islandora-Devops.tomcat9
     - role: role_under_test


### PR DESCRIPTION
**GitHub Issue**: [Update playbook to Ubuntu 20.04 Focal64](https://github.com/Islandora/documentation/issues/1792)

# What does this Pull Request do?

Update to run on Tomcat 9 and Ubuntu 20.04

# What's new?

Update references to Tomcat9 and the Tomcat9 user, 'tomcat'.

# How should this be tested?


Test as part of the full playbook update. Bigdata should be deployed and get updated when Islandora objects are updated.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
